### PR TITLE
fix: cancel stale channel list requests

### DIFF
--- a/src/components/chatPage/ChannelList/ChannelList.jsx
+++ b/src/components/chatPage/ChannelList/ChannelList.jsx
@@ -66,13 +66,15 @@ function ChannelList({ className = '', selectedChannelId = null }) {
     }
   }, [chatHub, activeChannelType])
 
-  const loadChannels = async ({ searchField, pageNumber, pageSize, type }) => {
+  const loadChannels = async ({ searchField, pageNumber, pageSize, type, signal }) => {
     const { data, response } = await api.channel.accountChannels({
       searchField,
       pageNumber,
       pageSize,
       channelType: type
     })
+
+    if (signal?.aborted) return
 
     if (response?.data?.clientMessage) {
       throw new Error(response.data.clientMessage)
@@ -92,7 +94,7 @@ function ChannelList({ className = '', selectedChannelId = null }) {
   }
 
   const refreshChannels = useCallback(
-    async (search, isSmoothScroll) => {
+    async (search, isSmoothScroll, signal) => {
       const scrollBehavior = isSmoothScroll ? 'smooth' : 'auto'
 
       pageNumberRef.current = 0
@@ -108,12 +110,15 @@ function ChannelList({ className = '', selectedChannelId = null }) {
           pageNumber: pageNumberRef.current,
           pageSize: defaultPageSize,
           searchField: search,
-          type: activeChannelType
+          type: activeChannelType,
+          signal
         })
       } catch (err) {
         // temp
       } finally {
-        setIsListLoading(false)
+        if (!signal?.aborted) {
+          setIsListLoading(false)
+        }
       }
     },
     [activeChannelType]
@@ -124,7 +129,9 @@ function ChannelList({ className = '', selectedChannelId = null }) {
   }
 
   useEffect(() => {
-    refreshChannels(debouncedSearchChannel)
+    const abortController = new AbortController()
+    refreshChannels(debouncedSearchChannel, false, abortController.signal)
+    return () => abortController.abort()
   }, [debouncedSearchChannel, refreshChannels])
 
   const scrollHandler = async (event) => {


### PR DESCRIPTION
## Summary
- Fix race condition where switching channel tabs quickly causes the wrong tab's results to display
- Uses AbortController to cancel outdated requests when tab or search changes

## Test plan
- [ ] Switch between All/Public/Private/Direct tabs quickly and verify correct channels display
- [ ] Type in search while switching tabs — verify no stale results appear